### PR TITLE
fix the dependency of matplotlib for blender

### DIFF
--- a/dataset/blender/sphere.py
+++ b/dataset/blender/sphere.py
@@ -1,5 +1,5 @@
 import numpy as np
-from matplotlib import pyplot as plt
+
 
 
 def get_positions(theta_range=(0, np.pi * 2),
@@ -51,7 +51,7 @@ def get_positions(theta_range=(0, np.pi * 2),
 if __name__ == '__main__':
 
     x, y, z, _ = get_positions()
-
+    from matplotlib import pyplot as plt
     from mpl_toolkits.mplot3d import Axes3D
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')


### PR DESCRIPTION
matplotlib can not run directly under python of blender

tested in ubuntu 19.10 with blender 2.79